### PR TITLE
Update retriever to use config.yaml

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,8 +5,6 @@ name: docs
 on:
   push:
     branches: [master]
-  pull_request:
-    branches: [master]
 
 jobs:
   build:
@@ -16,11 +14,15 @@ jobs:
       - uses: actions/checkout@v2
 
       # Example of using a custom build-command.
-
       - uses: ammaraskar/sphinx-action@master
         with:
           docs-folder: "docs/"
 
+      # Create an artifact of the html output.
+      - uses: actions/upload-artifact@v1
+        with:
+          name: DocumentationHTML
+          path: docs/_build/html/
 
       # Publish built docs to gh-pages branch.
       # ===============================

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ neuralqa/data
 docs/images/extra
 config.yaml
 .vscode
+neuralqa/server/test_query.py
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## NeuralQA: A Usable Library for (Extractive) Question Answering on Large Datasets with BERT
 
-[![License: MIT](https://img.shields.io/github/license/victordibia/neuralqa?style=flat-square)](https://opensource.org/licenses/MIT)
-![docs](https://github.com/victordibia/neuralqa/workflows/docs/badge.svg)
+[![License: MIT](https://img.shields.io/github/license/victordibia/neuralqa)](https://opensource.org/licenses/MIT)
+![docs](https://github.com/victordibia/neuralqa/workflows/docs/badge.svg?style=flat-square)
 
 > Still in **alpha**, lots of changes anticipated.
 
@@ -21,7 +21,7 @@ pip3 install neuralqa
 neuralqa ui --port 4000
 ```
 
-navigate to [http://localhost:4000/#/](http://localhost:4000/#/). Learn about other command line options in the documentation [here](https://neuralqa.readthedocs.io/en/latest/usage.html#command-line-options).
+navigate to [http://localhost:4000/#/](http://localhost:4000/#/). Learn about other command line options in the documentation [here](https://victordibia.github.io/neuralqa/usage.html#command-line-options).
 
 > Note: To use NeuralQA with a retriever such as ElasticSearch, follow the [instructions here](https://www.elastic.co/downloads/elasticsearch) to download, install, and launch a local elasticsearch instance and add it to your config.yaml file.
 
@@ -34,6 +34,8 @@ NeuralQA is comprised of several high level modules:
 - **Retriever**: For each search query (question), scan an index (elasticsearch), and retrieve a list of candidate matched passages.
 
 - **Reader**: For each retrieved passage, a BERT based model predicts a span that contains the answer to the question. In practice, retrieved passages may be lengthy and BERT based models can process a maximum of 512 tokens at a time. NeuralQA handles this in two ways. Lengthy passages are chunked into smaller sections with a configurable stride. Secondly, NeuralQA offers the option of extracting a subset of relevant snippets (RelSnip) which a BERT reader can then scan to find answers. Relevant snippets are portions of the retrieved document that contain exact match results for the search query.
+
+- **Expander**: Methods for generating additional queries to improve recall.
 
 - **User Interface**: NeuralQA provides a visual user interface for performing queries (manual queries where question and context are provided as well as queries over a search index), viewing results and also sensemaking of results (reranking of passages based on answer scores, highlighting keyword match, model explanations).
 
@@ -78,7 +80,6 @@ reader:
 ## Documentation
 
 An attempt is being made to better document NeuralQA here - [https://victordibia.github.io/neuralqa/](https://victordibia.github.io/neuralqa/).
- 
 
 ## Citation
 

--- a/neuralqa/cli.py
+++ b/neuralqa/cli.py
@@ -3,6 +3,7 @@ from neuralqa.server import launch_server
 from neuralqa.utils import cli_args
 from neuralqa.utils import import_case_data, ConfigParser
 import os
+from neuralqa.retriever import RetrieverPool
 
 
 @click.group()
@@ -17,9 +18,10 @@ def cli():
 @cli_args.WORKERS
 @cli_args.CONFIG_PATH
 def test(host, port, workers, config_path):
-    config = ConfigParser(config_path)
-    print(config.config["reader"]["models"])
-    # import_case_data()
+    # config = ConfigParser(config_path)
+    # rp = RetrieverPool(config.config["retriever"])
+    # print((rp.retriever_pool))
+    import_case_data()
 
 
 @cli.command()

--- a/neuralqa/config_default.yaml
+++ b/neuralqa/config_default.yaml
@@ -15,7 +15,7 @@ ui:
       samples: True # show/hide sample question answer pairs
       passages: True # show/hide passages which are retrieved
       explanations: True # show/hide explanations button
-      allanswers: True # show all answers or just the best answer (based on probability score)
+      allanswers: False # show all answers or just the best answer (based on probability score)
       expander: False
     options:
       stride:
@@ -44,16 +44,14 @@ ui:
         title: Highlight Span
         selected: 250
         options:
-          - name: 150
-            value: 150
-          - name: 250
-            value: 250
           - name: 350
             value: 350
           - name: 450
             value: 450
           - name: 650
             value: 650
+          - name: 850
+            value: 850
     samples:
 
 retriever:
@@ -63,6 +61,8 @@ retriever:
   options:
     - name: Manual
       value: manual
+      type: manual
+
     - name: Case Law
       value: cases
       host: localhost
@@ -70,6 +70,17 @@ retriever:
       username: None
       password: None
       type: elasticsearch
+      fields:
+        body_field: casebody.data.opinions.text
+    - name: Medical
+      value: medical
+      host: localhost
+      port: 9200
+      username: None
+      password: None
+      type: elasticsearch
+      fields:
+        body_field: context
     - name: Supreme Court
       value: supremecourt
       host: localhost
@@ -77,6 +88,8 @@ retriever:
       username: None
       password: None
       type: elasticsearch
+      fields:
+        body_field: casebody
   readtopn: 0
 
 relsnip:
@@ -99,6 +112,12 @@ reader:
     - name: DistilBERT SQUAD2
       value: twmkn9/distilbert-base-uncased-squad2
       type: distilbert
+    - name: BERT SQUAD2
+      value: deepset/bert-base-cased-squad2
+      type: bert
+    # - name: Medical BERT SQUAD2   # example of a model with local files
+    #   value: /Users/victordibia/Downloads/meddistilbert
+    #   type: bert
 
 expander:
   title: Expander

--- a/neuralqa/reader/bertreader.py
+++ b/neuralqa/reader/bertreader.py
@@ -6,6 +6,8 @@ import numpy as np
 import time
 import logging
 
+logger = logging.getLogger(__name__)
+
 
 class BERTReader(Reader):
     def __init__(self, model_name, model_path, model_type="bert", **kwargs):

--- a/neuralqa/reader/reader.py
+++ b/neuralqa/reader/reader.py
@@ -17,13 +17,16 @@ logging.getLogger(
 logging.getLogger("transformers.modeling_tf_utils").setLevel(logging.ERROR)
 
 
+logger = logging.getLogger(__name__)
+
+
 class Reader:
     def __init__(self, model_name, model_path, model_type, **kwargs):
         self.load_model(model_name, model_path, model_type)
 
     def load_model(self, model_name, model_path, model_type):
-        logging.info(" >> loading HF model " +
-                     model_name + " from " + model_path)
+        logger.info(">> loading HF model " +
+                    model_name + " from " + model_path)
         self.type = model_type
         self.name = model_name
         self.tokenizer = AutoTokenizer.from_pretrained(

--- a/neuralqa/reader/readerpool.py
+++ b/neuralqa/reader/readerpool.py
@@ -2,6 +2,8 @@
 from neuralqa.reader import BERTReader
 import logging
 
+logger = logging.getLogger(__name__)
+
 
 class ReaderPool():
     def __init__(self, models):
@@ -26,6 +28,6 @@ class ReaderPool():
             self._selected_model = selected_model
         else:
             default_model = next(iter(self.reader_pool))
-            logging.info(
+            logger.info(
                 ">> Model you are attempting to use %s does not exist in model pool. Using the following default model instead %s ", selected_model, default_model)
             self._selected_model = default_model

--- a/neuralqa/retriever/__init__.py
+++ b/neuralqa/retriever/__init__.py
@@ -1,2 +1,3 @@
 from .retriever import *
 from .elasticsearchretriever import *
+from .retrieverpool import *

--- a/neuralqa/retriever/elasticsearchretriever.py
+++ b/neuralqa/retriever/elasticsearchretriever.py
@@ -4,45 +4,112 @@ import logging
 
 
 logging.getLogger("elasticsearch").setLevel(logging.CRITICAL)
+logger = logging.getLogger(__name__)
 
 
 class ElasticSearchRetriever(Retriever):
-    def __init__(self, index_type="elasticsearch", host="localhost", port=9200):
+    def __init__(self, index_type="elasticsearch", host="localhost", port=9200, **kwargs):
         Retriever.__init__(self, index_type)
 
-        self.es = Elasticsearch([{'host': host, 'port': port}])
+        self.username = ""
+        self.password = ""
+        self.body_field = ""
+        self.secondary_fields = []
+        self.host = host
+        self.port = port
+
+        allowed_keys = list(self.__dict__.keys())
+        self.__dict__.update((k, v)
+                             for k, v in kwargs.items() if k in allowed_keys)
+        self.es = Elasticsearch([{'host': self.host, 'port': self.port}])
         self.isAvailable = self.es.ping()
 
-    def run_query(self, index_name, search_query):
-        """Makes a query to the elastic search server with the given search_query parameters.
-        Also returns opinion_excerpt script field, which is a substring of the first opinion in the case
+        rejected_keys = set(kwargs.keys()) - set(allowed_keys)
 
-        Arguments:
-            search_query {[dictionary]} -- [contains a dictionary that corresponds to an elastic search query on the ]
+        if rejected_keys:
+            raise ValueError(
+                "Invalid arguments in ElasticSearchRetriever constructor:{}".format(rejected_keys))
 
-        Returns:
-            [dictionary] -- [dictionary of results from elastic search.]
-        """
-        query_result = None
+    def run_query(self, index_name, search_query, max_documents=5, highlight_span=100, relsnip=True, num_fragments=5, highlight_tags=True):
 
-        # return error as result on error.
-        # Calling function should check status before parsing result
+        tags = {"pre_tags": [""], "post_tags": [
+            ""]} if not highlight_tags else {}
+        highlight_params = {
+            "fragment_size": highlight_span,
+            "fields": {
+                self.body_field: tags
+            },
+            "number_of_fragments": num_fragments
+        }
+
+        search_query = {
+            "query": {
+                "multi_match": {
+                    "query":    search_query,
+                    "fields": [self.body_field] + self.secondary_fields
+                }
+            },
+            "size": max_documents
+        }
+
+        status = True
+        results = {}
+
+        if (relsnip):
+            search_query["_source"] = {"includes": [""]}
+            search_query["highlight"] = highlight_params
+        else:
+            search_query["_source"] = {"includes": [self.body_field]}
+
         try:
-            query_result = {
-                "status": True,
-                "result": self.es.search(index=index_name, body=search_query)
-            }
-        except ConnectionRefusedError as e:
-            query_result = {
-                "status": False,
-                "result": str(e)
-            }
-        except Exception as e:
-            query_result = {
-                "status": False,
-                "result": str(e)
-            }
-        return query_result
+            query_result = self.es.search(
+                index=index_name, body=search_query)
+            # RelSnip: for each document, we concatenate all
+            # fragments in each document and return as the document.
+            highlights = [".".join(hit["highlight"][self.body_field])
+                          for hit in query_result["hits"]["hits"] if "highlight" in hit]
+            docs = [((hit["_source"][self.body_field]))
+                    for hit in query_result["hits"]["hits"] if hit["_source"]]
+            took = query_result["took"]
+            results = {"took": took,  "highlights": highlights, "docs": docs}
+
+        except (ConnectionRefusedError, Exception) as e:
+            status = False
+            results["errormsg"] = str(e)
+
+        results["status"] = status
+        return results
+
+    # def run_query(self, index_name, search_query):
+    #     """Makes a query to the elastic search server with the given search_query parameters.
+    #     Also returns opinion_excerpt script field, which is a substring of the first opinion in the case
+
+    #     Arguments:
+    #         search_query {[dictionary]} -- [contains a dictionary that corresponds to an elastic search query on the ]
+
+    #     Returns:
+    #         [dictionary] -- [dictionary of results from elastic search.]
+    #     """
+    #     query_result = None
+
+    #     # return error as result on error.
+    #     # Calling function should check status before parsing result
+    #     try:
+    #         query_result = {
+    #             "status": True,
+    #             "result": self.es.search(index=index_name, body=search_query)
+    #         }
+    #     except ConnectionRefusedError as e:
+    #         query_result = {
+    #             "status": False,
+    #             "result": str(e)
+    #         }
+    #     except Exception as e:
+    #         query_result = {
+    #             "status": False,
+    #             "result": str(e)
+    #         }
+    #     return query_result
 
     def test_connection(self):
         try:

--- a/neuralqa/retriever/elasticsearchretriever.py
+++ b/neuralqa/retriever/elasticsearchretriever.py
@@ -13,8 +13,7 @@ class ElasticSearchRetriever(Retriever):
 
         self.username = ""
         self.password = ""
-        self.body_field = ""
-        self.secondary_fields = []
+        self.body_field = "" 
         self.host = host
         self.port = port
 
@@ -43,10 +42,11 @@ class ElasticSearchRetriever(Retriever):
         }
 
         search_query = {
+            "_source":{"includes": [self.body_field]},
             "query": {
                 "multi_match": {
                     "query":    search_query,
-                    "fields": [self.body_field] + self.secondary_fields
+                    "fields": [self.body_field] 
                 }
             },
             "size": max_documents
@@ -56,17 +56,17 @@ class ElasticSearchRetriever(Retriever):
         results = {}
 
         if (relsnip):
-            search_query["_source"] = {"includes": [""]}
+            # search_query["_source"] = {"includes": [""]} 
             search_query["highlight"] = highlight_params
-        else:
-            search_query["_source"] = {"includes": [self.body_field]}
+        # else:
+        #     search_query["_source"] = {"includes": [self.body_field]}
 
         try:
             query_result = self.es.search(
                 index=index_name, body=search_query)
             # RelSnip: for each document, we concatenate all
             # fragments in each document and return as the document.
-            highlights = [".".join(hit["highlight"][self.body_field])
+            highlights = [" ".join(hit["highlight"][self.body_field])
                           for hit in query_result["hits"]["hits"] if "highlight" in hit]
             docs = [((hit["_source"][self.body_field]))
                     for hit in query_result["hits"]["hits"] if hit["_source"]]
@@ -80,37 +80,7 @@ class ElasticSearchRetriever(Retriever):
         results["status"] = status
         return results
 
-    # def run_query(self, index_name, search_query):
-    #     """Makes a query to the elastic search server with the given search_query parameters.
-    #     Also returns opinion_excerpt script field, which is a substring of the first opinion in the case
-
-    #     Arguments:
-    #         search_query {[dictionary]} -- [contains a dictionary that corresponds to an elastic search query on the ]
-
-    #     Returns:
-    #         [dictionary] -- [dictionary of results from elastic search.]
-    #     """
-    #     query_result = None
-
-    #     # return error as result on error.
-    #     # Calling function should check status before parsing result
-    #     try:
-    #         query_result = {
-    #             "status": True,
-    #             "result": self.es.search(index=index_name, body=search_query)
-    #         }
-    #     except ConnectionRefusedError as e:
-    #         query_result = {
-    #             "status": False,
-    #             "result": str(e)
-    #         }
-    #     except Exception as e:
-    #         query_result = {
-    #             "status": False,
-    #             "result": str(e)
-    #         }
-    #     return query_result
-
+     
     def test_connection(self):
         try:
             self.es.cluster.health()

--- a/neuralqa/retriever/retrieverpool.py
+++ b/neuralqa/retriever/retrieverpool.py
@@ -10,10 +10,13 @@ class RetrieverPool():
 
         self.retriever_pool = {}
         for retriever in retrievers["options"]:
+            if (retriever["value"] in self.retriever_pool):
+                raise ValueError(
+                    "Duplicate retriever value : {} ".format(retriever["value"]))
+
             if (retriever["type"] == "elasticsearch"):
                 self.retriever_pool[retriever["value"]] = ElasticSearchRetriever(
-                    host=retriever["host"], port=retriever["port"], body_field=retriever["fields"]["body_field"],
-                    secondary_fields=retriever["fields"]["secondary_fields"])
+                    host=retriever["host"], port=retriever["port"], body_field=retriever["fields"]["body_field"])
             if (retriever["type"] == "solr"):
                 logger.info("We do not yet support Solr retrievers")
         self.selected_retriever = retrievers["selected"]
@@ -33,5 +36,5 @@ class RetrieverPool():
         else:
             default_retriever = next(iter(self.retriever_pool))
             logger.info(
-                ">> Retriever you are attempting to use %s does not exist in retriever pool. Using the following default retriever instead %s ", selected_retriever, default_retriever)
+                ">> Retriever you are attempting to use (%s) does not exist in retriever pool. Using the following default retriever instead %s ", selected_retriever, default_retriever)
             self._selected_retriever = default_retriever

--- a/neuralqa/retriever/retrieverpool.py
+++ b/neuralqa/retriever/retrieverpool.py
@@ -1,0 +1,37 @@
+
+from neuralqa.retriever import ElasticSearchRetriever
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class RetrieverPool():
+    def __init__(self, retrievers):
+
+        self.retriever_pool = {}
+        for retriever in retrievers["options"]:
+            if (retriever["type"] == "elasticsearch"):
+                self.retriever_pool[retriever["value"]] = ElasticSearchRetriever(
+                    host=retriever["host"], port=retriever["port"], body_field=retriever["fields"]["body_field"],
+                    secondary_fields=retriever["fields"]["secondary_fields"])
+            if (retriever["type"] == "solr"):
+                logger.info("We do not yet support Solr retrievers")
+        self.selected_retriever = retrievers["selected"]
+
+    @property
+    def retriever(self):
+        return self.retriever_pool[self.selected_retriever]
+
+    @property
+    def selected_retriever(self):
+        return self._selected_retriever
+
+    @selected_retriever.setter
+    def selected_retriever(self, selected_retriever):
+        if (selected_retriever in self.retriever_pool):
+            self._selected_retriever = selected_retriever
+        else:
+            default_retriever = next(iter(self.retriever_pool))
+            logger.info(
+                ">> Retriever you are attempting to use %s does not exist in retriever pool. Using the following default retriever instead %s ", selected_retriever, default_retriever)
+            self._selected_retriever = default_retriever

--- a/neuralqa/server/routehandlers.py
+++ b/neuralqa/server/routehandlers.py
@@ -5,15 +5,18 @@ import time
 from fastapi import APIRouter
 from typing import Optional
 from neuralqa.server.routemodels import Document, Answer, Explanation
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class Handler:
-    def __init__(self, reader_pool, retriever):
+    def __init__(self, reader_pool, retriever_pool):
         router = APIRouter()
         self.router = router
 
-        self._reader_pool = reader_pool
-        self._retriever = retriever
+        self.reader_pool = reader_pool
+        self.retriever_pool = retriever_pool
 
         @router.post("/answers")
         async def get_answers(params: Answer):
@@ -27,27 +30,9 @@ class Handler:
                 [type] -- [description]
             """
 
-            # switch to the selected model
-            self._reader_pool.selected_model = params.reader
-
-            # included_fields = ["name"]
-            # search_query = {
-            #     "_source": included_fields,
-            #     "query": {
-            #         "multi_match": {
-            #             "query":    params.question,
-            #             "fields": ["casebody.data.opinions.text", "name"]
-            #         }
-            #     },
-            #     "highlight": {
-            #         "fragment_size": params.highlight_span,
-            #         "fields": {
-            #             "casebody.data.opinions.text": {"pre_tags": [""], "post_tags": [""]},
-            #             "name": {}
-            #         }
-            #     },
-            #     "size": params.max_documents
-            # }
+            # switch to the selected model and retriever
+            self.reader_pool.selected_model = params.reader
+            self.retriever_pool.selected_retriever = params.retriever
 
             answer_holder = []
             response = {}
@@ -55,54 +40,31 @@ class Handler:
 
             # answer question based on provided context
             if (params.retriever == "manual"):
-                answers = self._reader_pool.model.answer_question(
+                answers = self.reader_pool.model.answer_question(
                     params.question, params.context, stride=params.tokenstride)
                 for answer in answers:
                     answer["index"] = 0
                     answer_holder.append(answer)
             # answer question based on retrieved passages from elastic search
             else:
-                body_field = "casebody"
-                secondary_fields = ["author"]
                 num_fragments = 5
-                query_results = self._retriever.run_query(params.retriever, params.question, body_field, secondary_fields,
-                                                          max_documents=params.max_documents, highlight_span=params.highlight_span,
-                                                          relsnip=params.relsnip, num_fragments=num_fragments, highlight_tags=False)
+                query_results = self.retriever_pool.retriever.run_query(params.retriever, params.question,
+                                                                        max_documents=params.max_documents, highlight_span=params.highlight_span,
+                                                                        relsnip=params.relsnip, num_fragments=num_fragments, highlight_tags=False)
 
                 if (not query_results["status"]):
                     return query_results
-                # query_result = self._retriever.run_query(
-                #     params.retriever, search_query)
+
+                # if relsnip is not enabled, read the entire document ... this is super slow
                 docs = query_results["highlights"] if params.relsnip else query_results["docs"]
 
                 for i, doc in enumerate(docs):
                     doc = doc.replace("\n", " ")
-                    print(doc)
-                    answers = self._reader_pool.model.answer_question(
+                    answers = self.reader_pool.model.answer_question(
                         params.question, doc, stride=params.tokenstride)
                     for answer in answers:
-                        print(answer)
                         answer["index"] = i
                         answer_holder.append(answer)
-
-                print(answer_holder)
-                # if query_result["status"]:
-                #     query_result = query_result["result"]
-                #     for i, hit in enumerate(query_result["hits"]["hits"]):
-                #         if ("casebody.data.opinions.text" in hit["highlight"]):
-                #             # context passage is a concatenation of highlights
-                #             if (params.relsnip):
-                #                 context = " .. ".join(
-                #                     hit["highlight"]["casebody.data.opinions.text"])
-                #             else:
-                #                 context = str(hit["_source"])
-                #                 # print(context)
-
-                #             answers = self._reader_pool.model.answer_question(
-                #                 params.question, context, stride=params.tokenstride)
-                #             for answer in answers:
-                #                 answer["index"] = i
-                #                 answer_holder.append(answer)
 
             # sort answers by probability
             answer_holder = sorted(
@@ -119,11 +81,9 @@ class Handler:
                 dictionary -- contains details on elastic search results.
             """
 
-            body_field = "casebody"
-            secondary_fields = ["author"]
             num_fragments = 5
-            query_results = self._retriever.run_query(params.retriever, params.question, body_field, secondary_fields,
-                                                      max_documents=params.max_documents, highlight_span=params.highlight_span, relsnip=True, num_fragments=num_fragments)
+            query_results = self.retriever_pool.retriever.run_query(
+                params.retriever, params.question, max_documents=params.max_documents, highlight_span=params.highlight_span, relsnip=True, num_fragments=num_fragments)
 
             return query_results
 
@@ -135,10 +95,12 @@ class Handler:
                 [dictionary]: [explanation , query, question, ]
             """
 
+            # TODO: Do we need to switch readers here?
+
             context = params.context.replace(
                 "<em>", "").replace("</em>", "")
 
-            gradients, token_words, token_types, answer_text = self._reader_pool.model.explain_model(
+            gradients, token_words, token_types, answer_text = self.reader_pool.model.explain_model(
                 params.question, context)
 
             explanation_result = {"gradients": gradients,

--- a/neuralqa/server/routemodels.py
+++ b/neuralqa/server/routemodels.py
@@ -11,6 +11,7 @@ class Document(BaseModel):
     highlight_span: int = 250
     retriever: Optional[str] = None
     expander: Optional[str] = None
+    relsnip: Optional[bool] = True
 
 
 class Answer(BaseModel):

--- a/neuralqa/server/routemodels.py
+++ b/neuralqa/server/routemodels.py
@@ -19,7 +19,7 @@ class Answer(BaseModel):
     question: str = "what is a fourth amendment right violation? "
     highlight_span: int = 250
     tokenstride: int = 50
-    context: str = "The fourth amendment kind of protects the rights of citizens .. such that they dont get searched"
+    context: Optional[str] = "The fourth amendment kind of protects the rights of citizens .. such that they dont get searched"
     reader: str = None
     relsnip: bool = True
     retriever: Optional[str] = "manual"

--- a/neuralqa/server/serve.py
+++ b/neuralqa/server/serve.py
@@ -2,7 +2,7 @@
 
 from neuralqa.reader import BERTReader, ReaderPool
 from neuralqa.server.routehandlers import Handler
-from neuralqa.retriever import ElasticSearchRetriever
+from neuralqa.retriever import ElasticSearchRetriever, RetrieverPool
 from neuralqa.utils import ConfigParser
 
 
@@ -12,13 +12,30 @@ import time
 import uvicorn
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
+from fastapi.middleware.cors import CORSMiddleware
 
+
+logger = logging.getLogger(__name__)
 
 config_path = os.environ.get("NEURALQA_CONFIG_PATH")
 app_config = ConfigParser(config_path)
 
 app = FastAPI()
 api = FastAPI(root_path="/api")
+
+
+origins = [
+    "http://localhost",
+    "http://localhost:3000",
+]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 root_file_path = os.path.dirname(os.path.abspath(__file__))
 static_folder_root = os.path.join(root_file_path, "ui/build")
@@ -43,8 +60,8 @@ async def ui_config():
 reader_pool = ReaderPool(app_config.config["reader"])
 
 # # define the search index to be used if any
-retriever = ElasticSearchRetriever()
+retriever_pool = RetrieverPool(app_config.config["retriever"])
 
-handlers = Handler(reader_pool, retriever)
+handlers = Handler(reader_pool, retriever_pool)
 # handlers = Handler(None, None)
 api.include_router(handlers.router)

--- a/neuralqa/server/server_app.py
+++ b/neuralqa/server/server_app.py
@@ -3,9 +3,9 @@ import uvicorn
 import os
 
 
-def launch_server(host="127.0.0.1", port=5000, workers=1):
+def launch_server(host="127.0.0.1", port=5000, workers=1, reload=False):
     uvicorn.run("neuralqa.server.serve:app", host=host, port=port, workers=workers,
-                log_level="info")
+                log_level="info", reload=reload)
 
 
 if __name__ == "__main__":

--- a/neuralqa/server/ui/src/components/Main.js
+++ b/neuralqa/server/ui/src/components/Main.js
@@ -53,7 +53,7 @@ class Main extends Component {
 
     this.serverBasePath =
       window.location.protocol + "//" + window.location.host;
-    // this.serverBasePath = "http://localhost:5000";
+    this.serverBasePath = "http://localhost:5000";
     this.configEndpoint = "/api/config";
   }
 

--- a/neuralqa/server/ui/src/components/Main.js
+++ b/neuralqa/server/ui/src/components/Main.js
@@ -53,7 +53,7 @@ class Main extends Component {
 
     this.serverBasePath =
       window.location.protocol + "//" + window.location.host;
-    this.serverBasePath = "http://localhost:5000";
+    // this.serverBasePath = "http://localhost:5000";
     this.configEndpoint = "/api/config";
   }
 

--- a/neuralqa/server/ui/src/components/queryview/QueryView.jsx
+++ b/neuralqa/server/ui/src/components/queryview/QueryView.jsx
@@ -67,7 +67,7 @@ class QueryView extends Component {
 
     this.serverBasePath =
       window.location.protocol + "//" + window.location.host;
-    this.serverBasePath = "http://localhost:5000";
+    // this.serverBasePath = "http://localhost:5000";
     this.passageEndpoint = "/api/documents";
     this.answerEndpoint = "/api/answers";
     this.explainEndpoint = "/api/explain";
@@ -411,7 +411,7 @@ class QueryView extends Component {
               className="highlightsection iblock lhmedium  "
               dangerouslySetInnerHTML={{
                 __html:
-                  "<span class='excerpttitle'> All highlights: </span> <span class='lhmedium '>" +
+                  "<span class='excerpttitle mediumdesc'> All highlights: </span> <span class='lhmedium mediumdesc'>" +
                   data +
                   "</span>",
               }}
@@ -838,7 +838,7 @@ class QueryView extends Component {
             <div className="mt10 mb10">
               <span className="boldtext">
                 {" "}
-                {this.state.passages["highlights"].length} Passages found.{" "}
+                {this.state.passages["highlights"].length} Documents found.{" "}
               </span>
               {this.state.passageIsLoading && (
                 <span className="mediumdesc"> Loading passages ... </span>

--- a/neuralqa/server/ui/src/components/queryview/queryview.css
+++ b/neuralqa/server/ui/src/components/queryview/queryview.css
@@ -16,7 +16,7 @@
   top: 10px;
 }
 
-.highlightsection > em,
+.highlightsection > span > em,
 .contextrow > em {
   background-color: #fcfcaa;
   padding: 0px 5px 0px 5px;

--- a/neuralqa/utils/config_utils.py
+++ b/neuralqa/utils/config_utils.py
@@ -4,6 +4,9 @@ import logging
 import shutil
 
 
+logger = logging.getLogger(__name__)
+
+
 class ConfigParser:
     def __init__(self, config_path):
 
@@ -15,24 +18,24 @@ class ConfigParser:
         if config_path and os.path.exists(config_path):
             self.config = self.load_config(config_path)
             # else:
-            #     logging.info("Supplied config file does not exist. " +
+            #     logger.info("Supplied config file does not exist. " +
             #                  os.path.join(os.getcwd(), config_path))
-            #     logging.info("Creating new config file at " +
+            #     logger.info("Creating new config file at " +
             #                  self.current_config_path)
             #     self.config = self.load_default_config()
         else:
 
             if (config_path and not os.path.exists(config_path)):
-                logging.info("Supplied config file does not exist. " +
-                             os.path.join(os.getcwd(), config_path))
+                logger.info(">> Supplied config file does not exist. " +
+                            os.path.join(os.getcwd(), config_path))
 
             if os.path.exists(self.current_config_path):
-                logging.info("Will use config.yaml file found in current directory " +
-                             self.current_config_path)
+                logger.info(">> Found config.yaml file found in current directory " +
+                            self.current_config_path)
                 self.config = self.load_config(self.current_config_path)
             else:
-                logging.info("Creating new config file at " +
-                             self.current_config_path)
+                logger.info("vCreating new config file at " +
+                            self.current_config_path)
                 shutil.copyfile(self.default_config_path,
                                 self.current_config_path)
                 self.config = self.load_default_config()

--- a/neuralqa/utils/data_utils.py
+++ b/neuralqa/utils/data_utils.py
@@ -6,6 +6,36 @@ import urllib.request
 import logging
 import lzma
 import json
+import tarfile 
+import hashlib
+
+
+logger = logging.getLogger(__name__)
+# index settings with analyzer to automatically remove stop words
+index_settings = {
+    "settings": {
+        "analysis": {
+            "analyzer": {
+                "stop_analyzer": {
+                    "type": "standard",
+                    "stopwords": "_english_"
+                }
+            }
+        }
+    },
+    "mappings": {
+        "properties": {
+            "casebody": {
+                "type": "text",
+                "analyzer": "stop_analyzer"
+            },
+            "name": {
+                "type": "text",
+                "analyzer": "stop_analyzer"
+            }
+        }
+    }
+}
 
 
 def create_index_from_json(index_name, file_path, max_docs=None):
@@ -24,35 +54,11 @@ def create_index_from_json(index_name, file_path, max_docs=None):
 
     es = Elasticsearch([{'host': 'localhost', 'port': 9200}])
 
-    index_settings = {
-        "settings": {
-            "analysis": {
-                "analyzer": {
-                    "stop_analyzer": {
-                        "type": "standard",
-                        "stopwords": "_english_"
-                    }
-                }
-            }
-        },
-        "mappings": {
-            "properties": {
-                "casebody.data.opinions.text": {
-                    "type": "text",
-                    "analyzer": "stop_analyzer"
-                },
-                "name": {
-                    "type": "text",
-                    "analyzer": "stop_analyzer"
-                }
-            }
-        }
-    }
     es.indices.create(
         index=index_name, body=index_settings, ignore=400)
 
     extension = os.path.splitext(file_path)[1]
-    logging.info(">> Creating index using file " + file_path)
+    logger.info(">> Creating index using file " + file_path)
     i = 0
     if extension == ".xz":
         with lzma.open(file_path) as f:
@@ -63,10 +69,10 @@ def create_index_from_json(index_name, file_path, max_docs=None):
                     index_status = es.index(
                         index=index_name, id=i, body=line)
                 except Exception as e:
-                    logging.info(
+                    logger.info(
                         "An error has occurred while creating index " + str(e))
                     break
-                # logging.info(index_status)
+                # logger.info(index_status)
                 if (i > max_docs):
                     break
     elif extension == ".json":
@@ -77,12 +83,86 @@ def create_index_from_json(index_name, file_path, max_docs=None):
                     index_status = es.index(
                         index=index_name, id=i, body=line, op_type="create")
                 except Exception as e:
-                    logging.info(
+                    logger.info(
                         "An error has occurred while creating index " + str(e))
                     break
                 if (i > max_docs):
                     break
-    logging.info(">> Creating index complete ")
+    logger.info(">> Creating index complete ")
+
+
+def import_scotus_files(max_docs=2000):
+    scotus_url = "https://www.courtlistener.com/api/bulk-data/opinions/scotus.tar.gz"
+    scotus_dir = "scotusdata"
+    index_name = "supremecourt"
+
+    if (not os.path.exists(scotus_dir)):
+        os.makedirs(scotus_dir, exist_ok=True)
+        logger.info(">>> Downloading supreme court case data")
+        ftpstream = urllib.request.urlopen(scotus_url)
+        thetarfile = tarfile.open(fileobj=ftpstream, mode="r|gz")
+        thetarfile.extractall(path=scotus_dir)
+        logger.info(">>> Download completed ")
+
+    logger.info(">> Creating %s index using %s documents",
+                index_name, str(max_docs))
+    scotus_files = os.listdir(scotus_dir)
+
+    
+    es = Elasticsearch([{'host': 'localhost', 'port': 9200}])
+
+    es.indices.create(
+        index=index_name, body=index_settings, ignore=400)
+
+    i = 0
+    for file_path in (scotus_files):
+        with open("scotusdata/" + file_path) as json_file:
+            scotus_case = json.load(json_file)
+            case = {"author": scotus_case["author"],
+                    "casebody": scotus_case["plain_text"]}
+            if (scotus_case["plain_text"] != ""):
+                try:
+                    index_status = es.index(
+                        index=index_name, id=scotus_case["id"], body=case)
+                except Exception as e:
+                    logger.info(
+                        "An error has occurred while creating index " + str(e))
+                    break
+                i += 1
+        if (i > max_docs):
+            break
+
+    logger.info(">> Index creation complete.")
+
+def import_medical_data(max_docs=2000):
+    covid_data_url = "https://raw.githubusercontent.com/victordibia/test/gh-pages/covid_bioasq.json"
+    data = urllib.request.urlopen(covid_data_url).read()
+    data = json.loads(data) 
+    index_name = "medical"
+
+    print(len(data["data"]))
+
+    es = Elasticsearch([{'host': 'localhost', 'port': 9200}])
+    es.indices.create(
+        index=index_name, body=index_settings, ignore=400)
+
+    seen_docs = set("") 
+    for row in data["data"]: 
+        digest = hashlib.md5(row["paragraphs"][0]["context"].encode('utf-8')).hexdigest()
+        if (digest not in seen_docs):  
+            seen_docs.add(digest)
+            med_doc = {"id":digest, "context":row["paragraphs"][0]["context"]}
+            try:
+                index_status = es.index(
+                        index=index_name, id=digest, body=med_doc)
+            except Exception as e:
+                print(str(e))
+                logger.info(
+                    "An error has occurred while creating index " + str(e))
+                break
+             
+            
+
 
 
 def download_data(data_url, source_name):
@@ -95,9 +175,9 @@ def download_data(data_url, source_name):
     os.makedirs("data", exist_ok=True)
     # download data from caselaw
     zip_file_path = source_name + ".zip"
-    logging.info("Downloading data file for " + source_name)
+    logger.info("Downloading data file for " + source_name)
     urllib.request.urlretrieve(data_url, zip_file_path)
-    logging.info(">> Downloaded data file " + zip_file_path)
+    logger.info(">> Downloaded data file " + zip_file_path)
 
     extract_dir = "temp" + source_name
     with zipfile.ZipFile(zip_file_path, 'r') as zip_ref:
@@ -106,7 +186,7 @@ def download_data(data_url, source_name):
         extract_dir)[0], "data", "data.jsonl.xz")
     final_file_path = os.path.join("data", source_name + "jsonl.xz")
     shutil.copyfile(data_file, final_file_path)
-    logging.info(">> Extracted and moved jsonl file to data folder")
+    logger.info(">> Extracted and moved jsonl file to data folder")
     shutil.rmtree(extract_dir)
     os.remove(zip_file_path)
     return final_file_path
@@ -122,3 +202,6 @@ def import_case_data(max_docs=2000):
     for data_path in caselaw_data_paths:
         file_path = download_data(data_path[0], data_path[1])
         create_index_from_json("cases", file_path, max_docs=max_docs)
+
+    import_scotus_files(max_docs=max_docs)
+    import_medical_data(max_docs=max_docs)

--- a/notes.md
+++ b/notes.md
@@ -57,10 +57,17 @@ Other implementation notes
 ## Serving UI/API
 
 - Serve both ui and api over same backend api. This simplifies build in that we can think of /ui as just another api end point. Users can still run the backend without the ui as long as they conform to api standards.  
-  Caveat .. some want to have varies exposures.
+  Caveat .. some want to have varied exposure.
 - expose front end but not api. Only front end should be able to call api
 - expose api to specific internal applications.
 - expose api to any applicaation
+
+## Retriever Interface on yaml
+
+- search fields [] : a list of the fields in the index we want to search on
+- title field (optional): this is used as a title if available, else the first n size of the body is used.
+- body field: a subset of this field is shown in the UI, this is also the field that is returned to the reader for reading.
+- body offset: snippet of body that is shown on ui
 
 ## TODO
 
@@ -90,8 +97,27 @@ Release Checklist
 - verify latest build of ui without debug flags ... e.g. setting port to loccal port
 - verify version bump
 - copy latest config.yaml to config-default.yaml
+- remove CORS testing harness for UI
+  - remove manual UI pointers to port 5000
+  - remove CORS allow rules on backend api
 
 ## FAQs
 
 - How does NeuralQA handle really long passages? BERT can process input of max size 512 tokes (question + context + special tokens), how does NeuralQA handle longer passages?
   We divide the context into multiple chunks (with some optional striding) and find answers within each chunk. For very very long passages, you can
+
+## Notes on Running/Testing Locally
+
+- Clone the repo
+- cd neuralqa
+- pip install -r requirements.txt
+- build the ui
+  - cd neuralqa/server/ui
+  - yarn install
+  - yarn build
+- python neuralqa/cli.py test
+  - the command above should load several datasets into your index. Ensure elasticsearch is running!!. Details are in neuralqa/utils/data_utils.py
+- python neuralqa/cli.py ui
+  - this should startup neuralqa and create config.yaml in the current directory. You can stop it with Ctrl + C.
+  - now modify config.yaml .. add a path to your own model folder
+  - restart neuralqa with command above.


### PR DESCRIPTION
- specify retriever search fields from config.yaml. also standardize /documents api endpoint to not contain any retriever specific fields. issue #26 
- cap number of chunks that bert should process
- refactor, add retriever pool
- refactor ui to parse standardized api return data structure
