### PR TITLE
Pin dependency versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-torch>=1.5.0
-tensorflow>=2.1.0
-transformers>=2.9.1
+torch==1.5.0
+tensorflow==2.4.0
+transformers==3.0.2
 uvicorn
 aiofiles
 fastapi
-elasticsearch>=7.7.1
-pyyaml>=3.13 
+elasticsearch==7.7.1
+pyyaml==3.13 
 spacy


### PR DESCRIPTION
# Purpose

The purpose of this PR is to introduce a quick-fix for #63 by pinning package dependency versions to ensure Transformers 4.x is not installed.